### PR TITLE
Add `BitcoinAgent` initialization to support tECDSA

### DIFF
--- a/rust/bitcoin_wallet/README.md
+++ b/rust/bitcoin_wallet/README.md
@@ -15,16 +15,18 @@ npm install
 
 While working on the Internet Computer does not require more configuration, working locally does. The additional instructions are provided in [the next section](#testing-locally).
 
-Run the following commands to deploy the development Internet Identity canister and the Bitcoin wallet canister locally:
+Run the following commands to deploy and initialize the development Internet Identity canister and the Bitcoin wallet canister locally:
 
 ```bash
 dfx deploy
+dfx canister call bitcoin_wallet initialize
 ```
 
-Run the following command to deploy the Bitcoin wallet canister on the Internet Computer:
+Run the following commands to deploy and initialize the Bitcoin wallet canister on the Internet Computer:
 
 ```bash
 II_CANISTER_ID=identity dfx deploy --network ic bitcoin_wallet_assets
+dfx canister --network ic call bitcoin_wallet initialize
 ```
 
 ## Testing locally

--- a/rust/bitcoin_wallet/dfx.json
+++ b/rust/bitcoin_wallet/dfx.json
@@ -37,7 +37,7 @@
       "packtool": ""
     }
   },
-  "dfx": "0.11.0-beta.1",
+  "dfx": "0.11.0",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/rust/bitcoin_wallet/src/bitcoin_wallet/lib.rs
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet/lib.rs
@@ -1,7 +1,7 @@
 use bitcoin::Address;
 use ic_btc_library::{
-    get_balance_from_args, get_current_fees_from_args, AddressType, BitcoinAgent,
-    ManagementCanister, ManagementCanisterImpl, Network, Satoshi,
+    get_balance_from_args, get_current_fees_from_args, get_initialization_parameters_from_args,
+    AddressType, BitcoinAgent, ManagementCanister, ManagementCanisterImpl, Network, Satoshi,
 };
 use ic_cdk::{api::caller, export::Principal, trap};
 use ic_cdk_macros::{query, update};
@@ -19,6 +19,23 @@ thread_local! {
             ADDRESS_TYPE,
             MIN_CONFIRMATIONS
         ).unwrap());
+}
+
+/// Initializes the Bitcoin agent.
+/// This custom endpoint needs to be called once. This endpoint can then be removed in a canister upgrade.
+#[update]
+async fn initialize() {
+    let get_initialization_parameters_args = BITCOIN_AGENT
+        .with(|bitcoin_agent| bitcoin_agent.borrow().get_initialization_parameters_args());
+    let initialization_parameters =
+        get_initialization_parameters_from_args(get_initialization_parameters_args)
+            .await
+            .unwrap();
+    BITCOIN_AGENT.with(|bitcoin_agent| {
+        bitcoin_agent
+            .borrow_mut()
+            .initialize(initialization_parameters)
+    });
 }
 
 /// Returns the user's `Principal`.

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
@@ -20,17 +20,11 @@ const init = ({ IDL }) => {
   return [];
 };
 
-function isLocalDFXNetwork() {
-  return process.env.DFX_NETWORK === "local" || process.env.DFX_NETWORK.startsWith("http___127_0_0_1_");
-}
-
-const port = process.env.DFX_NETWORK.startsWith("http___127_0_0_1_") ? process.env.DFX_NETWORK.replace("http___127_0_0_1_", "") : "8000";
-
 // Autofills the II Url to point to the correct canister.
 export const iiUrl =
-  isLocalDFXNetwork() ?
-    `http://localhost:${port}/?canisterId=${process.env.II_CANISTER_ID}` : (
-  (process.env.DFX_NETWORK === "ic") ?
+    (process.env.DFX_NETWORK === "local") ?
+    `http://localhost:8000/?canisterId=${process.env.II_CANISTER_ID}` : (
+    (process.env.DFX_NETWORK === "ic") ?
     `https://${process.env.II_CANISTER_ID}.ic0.app` :
     `https://${process.env.II_CANISTER_ID}.dfinity.network`
 );
@@ -58,7 +52,7 @@ export async function getWebApp() {
   const identity = authClient.getIdentity();
   // Using the identity obtained from the auth client, we can create an agent to interact with the IC.
   const agent = new HttpAgent({ identity });
-  if(isLocalDFXNetwork())
+  if(process.env.DFX_NETWORK === "local")
     await agent.fetchRootKey();
   // Using the interface description of our webapp, we create an actor that we use to call the service methods.
   return Actor.createActor(webapp_idl, {
@@ -74,3 +68,4 @@ export async function redirectToLoginIfUnauthenticated(webapp) {
     redirectToLogin();
   }
 }
+


### PR DESCRIPTION
With dfx 0.11.0 when starting dfx on port `N`, `process.env.DFX_NETWORK` value is `local` and no more `http___127_0_0_1_N` as it used to be the case.
I investigated it a bit and couldn't find any easy workaround to keep custom dfx port support, so I restored the port mechanism, [that we used to use](https://github.com/BenjaminLoison/examples/pull/6/files#diff-00fea48f038e703f5ab9dafd1e3a15027dc768a5f09dac3d471104745b3071ad), of the not customizable port from [the internet-identity using-dev-build demo](https://github.com/dfinity/internet-identity/tree/main/demos/using-dev-build).