### PR TITLE
[ER-2529] Enable the functionality to send Bitcoin

### DIFF
--- a/rust/bitcoin_wallet/src/bitcoin_wallet/Cargo.toml
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet/Cargo.toml
@@ -8,8 +8,8 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.5"
-ic-cdk-macros = "0.5"
+ic-cdk = "0.5.4"
+ic-cdk-macros = "0.5.4"
 ic-btc-library = { git = "https://github.com/dfinity/bitcoin-library" }
 getrandom = { version = "0.2", features = ["custom"] }
 bitcoin = "0.28.1"

--- a/rust/bitcoin_wallet/src/bitcoin_wallet/lib.rs
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet/lib.rs
@@ -16,7 +16,7 @@ const ADDRESS_TYPE: &AddressType = &AddressType::P2pkh;
 thread_local! {
     // The Bitcoin wallet uses a Bitcoin agent per user.
     static BITCOIN_AGENT_USERS: RefCell<BTreeMap<Principal, BitcoinAgent<ManagementCanisterImpl>>> = RefCell::new(BTreeMap::default());
-    // Initialized default Bitcoin agent for each user.
+    // Default Bitcoin agent used to setup a Bitcoin agent instance for each user.
     static BITCOIN_AGENT: RefCell<BitcoinAgent<ManagementCanisterImpl>> =
         RefCell::new(BitcoinAgent::new(
             ManagementCanisterImpl::new(NETWORK),
@@ -98,7 +98,7 @@ async fn get_user_address_str() -> String {
 /// Returns the user's balance in `Satoshi`s.
 #[update]
 async fn get_balance() -> Satoshi {
-    let principal_address = &get_user_address();
+    let user_address = &get_user_address();
     let get_utxos_args = BITCOIN_AGENT.with(|bitcoin_agent| {
         bitcoin_agent
             .borrow()
@@ -119,7 +119,7 @@ async fn get_fees() -> (Satoshi, Satoshi, Satoshi) {
     (current_fees[25], current_fees[50], current_fees[75])
 }
 
-/// Sends a transaction, transferring the specified Bitcoin amounts to the provided address.
+/// Sends a transaction, transferring the specified Bitcoin amount to the provided address.
 #[update]
 async fn transfer(
     address: String,

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
@@ -62,7 +62,7 @@ const webapp_idl = ({ IDL }) => {
 
   return IDL.Service({
     whoami: IDL.Func([], [IDL.Principal], ["query"]),
-    get_principal_address_str: IDL.Func([], [IDL.Text], ["update"]),
+    get_user_address_str: IDL.Func([], [IDL.Text], ["update"]),
     get_balance: IDL.Func([], [Satoshi], ["update"]),
     get_fees: IDL.Func([], [MillisatoshiPerByte, MillisatoshiPerByte, MillisatoshiPerByte], ["update"]),
     transfer: IDL.Func([IDL.Text, Satoshi, MillisatoshiPerByte, IDL.Bool], [TransferResult], ["update"]),

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
@@ -5,14 +5,67 @@ const webapp_id = process.env.BITCOIN_WALLET_CANISTER_ID;
 
 // The interface of the Bitcoin wallet canister.
 const webapp_idl = ({ IDL }) => {
+  const TransactionID = IDL.Text;
   const Satoshi = IDL.Nat64;
+  const Millisatoshi = IDL.Nat64;
   const MillisatoshiPerByte = IDL.Nat64;
+
+  const Network = IDL.Variant({
+      'Mainnet' : IDL.Null,
+      'Testnet' : IDL.Null,
+      'Regtest' : IDL.Null,
+  });
+
+  const AddressUsingPrimitives = IDL.Tuple(IDL.Text, Network);
+
+  const OutPoint = IDL.Record({
+      txid : IDL.Vec(IDL.Nat8),
+      vout : IDL.Nat32,
+  });
+
+  const Utxo = IDL.Record({
+      outpoint : OutPoint,
+      value : Satoshi,
+      height : IDL.Nat32,
+  });
+
+  const TransactionInfo = IDL.Record({
+      id : TransactionID,
+      utxos_addresses : IDL.Vec(IDL.Tuple(AddressUsingPrimitives, IDL.Vec(Utxo))),
+      fee : Satoshi,
+      size : IDL.Nat32,
+      timestamp : IDL.Nat64,
+  });
+
+  const RejectionCode = IDL.Variant({
+      'NoError' : IDL.Null,
+      'SysFatal' : IDL.Null,
+      'SysTransient' : IDL.Null,
+      'DestinationInvalid' : IDL.Null,
+      'CanisterReject' : IDL.Null,
+      'CanisterError' : IDL.Null,
+      'Unknown' : IDL.Null,
+  });
+
+  const MultiTransferError = IDL.Variant({
+      'InvalidPercentile' : IDL.Null,
+      'InsufficientBalance' : IDL.Null,
+      'MinConfirmationsTooHigh' : IDL.Null,
+      'UnsupportedSourceAddressType' : IDL.Null,
+      'ManagementCanisterReject' : IDL.Tuple(RejectionCode, IDL.Text),
+  });
+
+  const TransferResult = IDL.Variant({
+      'Ok' : TransactionInfo,
+      'Err' : MultiTransferError,
+  });
 
   return IDL.Service({
     whoami: IDL.Func([], [IDL.Principal], ["query"]),
     get_principal_address_str: IDL.Func([], [IDL.Text], ["update"]),
     get_balance: IDL.Func([], [Satoshi], ["update"]),
     get_fees: IDL.Func([], [MillisatoshiPerByte, MillisatoshiPerByte, MillisatoshiPerByte], ["update"]),
+    transfer: IDL.Func([IDL.Text, Satoshi, MillisatoshiPerByte, IDL.Bool], [TransferResult], ["update"]),
   });
 };
 

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/receive.js
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/receive.js
@@ -4,9 +4,9 @@ window.onload = async () => {
   const webapp = await getWebApp();
   // If the user isn't authenticated, then he is redirected to the login webpage.
   redirectToLoginIfUnauthenticated(webapp);
-  // Calls `get_principal_address_str` which returns the Bitcoin address of the current user.
+  // Calls `get_user_address_str` which returns the Bitcoin address of the current user.
   // This call takes time because it is an update call for security reason.
-  const address = (await webapp.get_principal_address_str());
+  const address = (await webapp.get_user_address_str());
   // Shows the Bitcoin address on the page.
   document.getElementById("address").innerText = address;
 };

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/send.html
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/send.html
@@ -1,0 +1,22 @@
+<h2>Send bitcoin</h2>
+<button id="backToDashboardBtn">Back to dashboard</button>
+<section>
+  Address: <input type="text" id="address"></input><br/>
+  Amount: <input type="number" id="amount" min="0" step="0.00000001"></input><button id="setMaxAmountBtn">max</button><br/>
+
+  Fee: <input type="number" id="feeMSatB"></input> msat/B<br/>
+
+  <label for="low">low</label>
+  <input type="radio" id="low" name="feeLevel" value="low"><br/>
+
+  <label for="std">std</label>
+  <input type="radio" id="std" name="feeLevel" value="std" checked><br/>
+
+  <label for="high">high</label>
+  <input type="radio" id="high" name="feeLevel" value="high"><br/>
+
+  <label for="allowRBF">Allow RBF</label>
+  <input type="checkbox" id="allowRBF"></input><br/>
+
+  <button id="sendBtn">Send</button>
+</section>

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/send.js
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/send.js
@@ -1,0 +1,57 @@
+import { redirectToDashboard, redirectToLoginIfUnauthenticated, getWebApp } from './common.js';
+
+window.onload = async () => {
+  window.webapp = await getWebApp();
+  redirectToLoginIfUnauthenticated(window.webapp);
+  window.balance = await window.webapp.get_balance();
+  window.balance = Number(window.balance) / (10 ** 8);
+  document.getElementById("amount").max = window.balance;
+  window.fees = await window.webapp.get_fees();
+  refreshFeeRate();
+};
+
+function refreshFeeRate() {
+  const feeLevel = document.querySelector('input[name="feeLevel"]:checked').value;
+  var feeLevelIndex;
+  switch (feeLevel) {
+    case 'high':
+      feeLevelIndex = 2;
+      break;
+    case 'std':
+      feeLevelIndex = 1;
+      break;
+    default:
+      feeLevelIndex = 0;
+  }
+
+  const fee = window.fees[feeLevelIndex];
+  document.getElementById("feeMSatB").value = fee;
+}
+
+document.getElementById("backToDashboardBtn").addEventListener("click", async () => {
+  redirectToDashboard();
+});
+
+document.getElementById("setMaxAmountBtn").addEventListener("click", async () => {
+  document.getElementById("amount").value = window.balance;
+});
+
+["low", "std", "high"].forEach(function(feeLevel) {
+  document.getElementById(feeLevel).addEventListener("click", async () => {
+    refreshFeeRate();
+  });
+});
+
+document.getElementById("sendBtn").addEventListener("click", async () => {
+  const address = document.getElementById("address").value;
+  const amount = parseFloat(document.getElementById("amount").value) * (10 ** 8);
+  const fee = parseInt(document.getElementById("feeMSatB").value);
+  const allowRBF = document.getElementById("allowRBF").checked;
+  const transferResult = await window.webapp.transfer(address, amount, fee, allowRBF);
+  const transferResultStr = JSON.stringify(transferResult, (key, value) =>
+    typeof value === 'bigint'
+      ? value.toString()
+      : value
+  );
+  alert(transferResultStr);
+});

--- a/rust/bitcoin_wallet/webpack.config.js
+++ b/rust/bitcoin_wallet/webpack.config.js
@@ -45,7 +45,7 @@ function initCanisterIds() {
 initCanisterIds();
 
 // These are the webpages of the website.
-const files = ["index", "dashboard", "receive"];
+const files = ["index", "dashboard", "receive", "send"];
 
 function get_src_path(file) {
   return path.join(__dirname, path.join("src", "bitcoin_wallet_assets", "src", file));


### PR DESCRIPTION
[[ER-2529]](https://dfinity.atlassian.net/browse/ER-2529) Enable the functionality to send Bitcoin

This PR adds the ability for users to send bitcoins by using a different set of UTXOs for each user.
The Bitcoin wallet now uses an initialized default Bitcoin agent that is cloned for each user and this default Bitcoin agent is also used for read-only operations.

Note that this PR:
- renames `get_principal_address` to `get_user_address` and `get_principal_address_str` to `get_user_address_str`
- updates `ic-cdk` and `ic-cdk-macros` from `0.5` to `0.5.4` to add `CandidType` to `RejectionCode`