### PR TITLE
Complete `bitcoin_wallet.did`

### DIFF
--- a/rust/bitcoin_wallet/src/bitcoin_wallet/bitcoin_wallet.did
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet/bitcoin_wallet.did
@@ -1,9 +1,62 @@
+type TransactionID = text;
 type Satoshi = nat64;
 type MillisatoshiPerByte = nat64;
+
+type Network = variant {
+    Mainnet : null,
+    Testnet : null,
+    Regtest : null,
+};
+
+type AddressUsingPrimitives = record { text; Network };
+
+type OutPoint = record {
+    txid : vec nat8,
+    vout : nat32,
+};
+
+type Utxo = record {
+    outpoint : OutPoint,
+    value : Satoshi,
+    height : nat32,
+};
+
+type TransactionInfo = record {
+    id : TransactionID,
+    utxos_addresses : vec (record { AddressUsingPrimitives; vec Utxo }),
+    fee : Satoshi,
+    size : nat32,
+    timestamp : nat64,
+};
+
+type RejectionCode = variant {
+    NoError : null,
+    SysFatal : null,
+    SysTransient : null,
+    DestinationInvalid : null,
+    CanisterReject : null,
+    CanisterError : null,
+    Unknown : null,
+};
+
+type TransferError = variant {
+    MalformedDestinationAddress : null,
+    InvalidPercentile : null,
+    InsufficientBalance : null,
+    MinConfirmationsTooHigh : null,
+    UnsupportedSourceAddressType : null,
+    ManagementCanisterReject : record { RejectionCode; text },
+};
+
+type TransferResult = variant {
+    Ok : TransactionInfo,
+    Err : TransferError,
+};
 
 service : {
     whoami: () -> (text) query;
     get_principal_address_str: () -> (text);
     get_balance: () -> (Satoshi);
     get_fees: () -> (MillisatoshiPerByte, MillisatoshiPerByte, MillisatoshiPerByte);
+    transfer: (text, Satoshi, MillisatoshiPerByte, bool) -> (TransferResult)
 }

--- a/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
+++ b/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js
@@ -7,7 +7,6 @@ const webapp_id = process.env.BITCOIN_WALLET_CANISTER_ID;
 const webapp_idl = ({ IDL }) => {
   const TransactionID = IDL.Text;
   const Satoshi = IDL.Nat64;
-  const Millisatoshi = IDL.Nat64;
   const MillisatoshiPerByte = IDL.Nat64;
 
   const Network = IDL.Variant({


### PR DESCRIPTION
This PR is based on [the interface used in the test front-end](https://github.com/BenjaminLoison/examples/blob/a1e7dcc951e46b5f107e9ae2cc3362cf9f95b932/rust/bitcoin_wallet/src/bitcoin_wallet_assets/src/common.js#L6-L71).